### PR TITLE
Fix some documentation mistakes

### DIFF
--- a/docs/feature/advancements.md
+++ b/docs/feature/advancements.md
@@ -1,6 +1,6 @@
 # Advancements
 
-The advancement API is based around `AdvancementTab`s which represent a tree of `Advancement`s for one or more players. Each player viewing a single `AdvancementTab` will see the same progress as all of the others. If per player `Advancement`s are needed, individual `AdvancementTab`s will need to be created.
+The advancement API is based around `AdvancementTab`s which represent a tree of `Advancement`s for one or more players. Each player viewing a single `AdvancementTab` will see the same progress as all the others. If per player `Advancement`s are needed, individual `AdvancementTab`s will need to be created.
 
 `Advancement`s represent a completable advancement in an `AdvancementTab`.
 
@@ -18,7 +18,7 @@ AdvancementManager#getTab(String /* namespaced id */);
 
 > Namespaced IDs follow the format of `namespace:id`, and may not have any upper case letters.
 
-An `AdvancementRoot` is the origin `Advancement` for a tab, and has the same creation method as a regular `Advancement` (see below) with the exception of the background. A background is a reference to a texture file on the client, for example `minecraft:textures/block/stone.png` for stone block.
+An `AdvancementRoot` is the origin `Advancement` for a tab, and has the same creation method as a regular `Advancement` (see below) except the background. A background is a reference to a texture file on the client, for example `minecraft:textures/block/stone.png` for stone block.
 
 ```java
 AdvancementRoot#<init>(Component, Component, Material, FrameType, int, int, String /* background */);
@@ -49,4 +49,4 @@ Once an `Advancement` is registered, it can be completed.
 Advancement#setAchieved(Boolean);
 ```
 
-> To make an advancement show a toast, use `Advancement#showToast(Boolean)` before setting it to achieved.
+> To make an advancement show a toast, use `Advancement#showToast(Boolean)` before setting it to be achieved.

--- a/docs/feature/adventure.md
+++ b/docs/feature/adventure.md
@@ -66,7 +66,7 @@ The `all()` and `of(Predicate)` methods will collect every custom audience using
 
 ### Packet grouping
 
-Minestom also provides a new `ForwardingAudience` implementation called `PacketGroupingAudience`. This is implemented by every audience in Minestom that has multiple players. Instead of the normal `ForwardingAudience` implementation that iterates through the audience members, this implementation uses `PacketUtils#sendGroupedPacket(Collection, ServerPacket)` to attempt to send a grouped packet to all of the players in this audience.
+Minestom also provides a new `ForwardingAudience` implementation called `PacketGroupingAudience`. This is implemented by every audience in Minestom that has multiple players. Instead of the normal `ForwardingAudience` implementation that iterates through the audience members, this implementation uses `PacketUtils#sendGroupedPacket(Collection, ServerPacket)` to attempt to send a grouped packet to all the players in this audience.
 
 To create your own `PacketGroupingAudience`, you can use the static `of(Collection)` and `of(Iterable)` methods in the class which return an instance of `PacketGroupingAudience` when provided a group of players.
 
@@ -163,7 +163,7 @@ For example, in the old API you would use the following code:
 player.playSound(SoundEvent.MUSIC_DISC_11, SoundCategory.RECORDS, 1f, 1f);
 ```
 
-With Adventure you would use the following code:
+With Adventure, you would use the following code:
 
 ```java
 player.playSound(Sound.sound(SoundEvent.MUSIC_DISC_11, Source.RECORD, 1f, 1f));
@@ -179,7 +179,7 @@ The `net.minestom.server.chat` package has been entirely deprecated. To construc
 
 Another difference between the old chat API and Adventure is that you cannot use colors inside a string to create messages. In the old API you could do `ChatColor.RED + "some text"`. This is not possible with Adventure as it does not properly represent how text is stored in Minecraft. Instead, you can set the style of components using the methods found in the `Component` class, such as `Component.text(String, TextColor)`, or by setting the style using the `Style` method.
 
-Adventure also splits the old API's `ChatColor` class into classes for `TextColor` and `TextDecoration`. `TextDecoration` can also be negated, meaning you can remove styles from nested components whilst not impacting components that may follow this one. The old `ChatColor` class has been deprecated and replaced with new classes for `Color` and `DyeColor` across the Minestom codebase. Both of these implement `RgbLike` and can be used to color Adventure components.
+Adventure also splits the old APIs `ChatColor` class into classes for `TextColor` and `TextDecoration`. `TextDecoration` can also be negated, meaning you can remove styles from nested components whilst not impacting components that may follow this one. The old `ChatColor` class has been deprecated and replaced with new classes for `Color` and `DyeColor` across the Minestom codebase. Both of these implement `RgbLike` and can be used to color Adventure components.
 
 Hover and click events can be added to any `Component` using `.hoverEvent()` and `.clickEvent`. Instead of using `ChatHoverEvent.showItem(ItemStack)` you can instead put an `ItemStack` directly into the argument of a hover event. For example, in the old chat API you would do:
 

--- a/docs/feature/entities/ai.md
+++ b/docs/feature/entities/ai.md
@@ -36,7 +36,7 @@ public class ZombieCreature extends EntityCreature {
             List.of(
                 new MeleeAttackGoal(this, 1.6, 20, TimeUnit.SERVER_TICK), // Attack the target
                 new RandomStrollGoal(this, 20) // Walk around
-            )
+            ),
             List.of(
                 new LastEntityDamagerTarget(this, 32), // First target the last entity which attacked you
                 new ClosestEntityTarget(this, 32, entity -> entity instanceof Player) // If there is none, target the nearest player

--- a/docs/feature/events/implementation.md
+++ b/docs/feature/events/implementation.md
@@ -8,9 +8,9 @@ Understanding what happens when an event is called or when a new node is added c
 
 ## Listener handle
 
-A `ListenerHandle` represents a direct access to an event type listeners, they are stored inside the node and must be retrieved for the listeners to be executed
+A `ListenerHandle` represents direct access to an event type listeners, they are stored inside the node and must be retrieved for the listeners to be executed
 
-`EventNode#call(Event)` is as simple as retrieving the handle (through a map lookup) and executing `ListenerHandle#call(Event)`. As you may have realize, you could completely avoid the map lookup by directly using the handle, hence why `EventNode#getHandle(Class<Event>)` exists!
+`EventNode#call(Event)` is as simple as retrieving the handle (through a map lookup) and executing `ListenerHandle#call(Event)`. As you may have realized, you could completely avoid the map lookup by directly using the handle, hence why `EventNode#getHandle(Class<Event>)` exists!
 
 Keeping the handle in a field instead of doing map lookups for every event call may also help the JIT to entirely avoid the event object allocation in case where there are no listener.
 

--- a/docs/feature/events/server-list-ping.md
+++ b/docs/feature/events/server-list-ping.md
@@ -4,7 +4,7 @@ description: Responding to all types of server list ping in one place.
 
 # Server list ping
 
-Minestom provides the ability to customise responses to five different server list ping types all in one place. Put simply, to listen to every type of server list ping event you just need to listen to the `ServerListPingEvent` and modify the `ResponseData` in the event. Regardless of the source of the ping, the response data will be formatted in the correct way for the corrosponding source.
+Minestom provides the ability to customise responses to five different server list ping types all in one place. Put simply, to listen to every type of server list ping event you just need to listen to the `ServerListPingEvent` and modify the `ResponseData` in the event. Regardless of the source of the ping, the response data will be formatted in the correct way for the corresponding source.
 
 ## Ping types
 
@@ -56,7 +56,7 @@ For more information on opening a server to LAN, see the [Open to LAN](../open-t
 
 After receiving the server list ping response, modern clients send an additional packet intended to calculate latency. Minestom provides the `ClientPingServerEvent` for this.
 
-The event may be cancelled, in which case a response packet will not be sent. However, various delay methods can affect the apparant latency:
+The event may be cancelled, in which case a response packet will not be sent. However, various delay methods can affect the apparent latency:
 
 ```java
 event.setDelay(new UpdateOption(5, TimeUnit.SECOND));

--- a/docs/feature/inventories.md
+++ b/docs/feature/inventories.md
@@ -31,13 +31,13 @@ EventNode.type("click", EventFilter.INVENTORY, (event, inv) -> inventory == inv)
 
 - Inventory classes have been renamed. `AbstractInventory` is now `Inventory`, and what was `Inventory` is now `ContainerInventory`. This makes the hierarchy a bit clearer. To be clear, `ContainerInventory` represents all named inventories (e.g. chest inventories, anvil inventories, crafting inventories).
 
-- Click events with `#getClickedItem()`, `#getClickType()`, `#getSlot()`, etc. have been replaced with the `Click.Info` type. This is an interface permitting a bunch of subclasses, including `Left`, `Right`, `RightShift`, etc, each storing the relevant slots. When listening to an event, you can simply check the click type:
+- Click events with `#getClickedItem()`, `#getClickType()`, `#getSlot()`, etc. have been replaced with the `Click.Info` type. This is an interface permitting a bunch of subclasses, including `Left`, `Right`, `RightShift`, etc., each storing the relevant slots. When listening to an event, you can simply check the click type:
   `if (event.getClickInfo() instanceof Click.Info.Left left) { /* logic */ }`
 
 - Inventory click events have been refactored to the following structure:
 
   - InventoryPreClickEvent
-    - Allows modification of the raw information about the click (e.g. clicked slots, click type, which button was used, etc) via `event.getClickInfo()`.
+    - Allows modification of the raw information about the click (e.g. clicked slots, click type, which button was used, etc.) via `event.getClickInfo()`.
     - This occurs before the click is processed.
   - InventoryClickEvent
     - Allows modification of the slot changes and side effects that occur as result of the click via `event.getChanges()` instead of just the click info.

--- a/docs/feature/map-rendering.md
+++ b/docs/feature/map-rendering.md
@@ -29,7 +29,7 @@ mapData.columns = COLUMN_COUNT;
 - `rows` is an unsigned byte (stored inside a `short`) which represents the number of rows to update.
 - `columns` is an unsigned byte (stored inside a `short`) which represents the number of columns to update.
 
-Pixels are stored in a row-major configuration (ie index is defined by `x+width*y`). Attempting to write pixels outside of the 128x128 area WILL crash and/or disconnect the client, so be careful. Minestom does not check which area you are writing to.
+Pixels are stored in a row-major configuration (ie index is defined by `x+width*y`). Attempting to write pixels outside the 128x128 area WILL crash and/or disconnect the client, so be careful. Minestom does not check which area you are writing to.
 
 You can then send the packet to players through `PlayerConnection#sendPacket(ServerPacket)`
 

--- a/docs/feature/map-rendering/glfwmaprendering.md
+++ b/docs/feature/map-rendering/glfwmaprendering.md
@@ -8,7 +8,7 @@ _GLFW capable framebuffers require access to an API supported by GLFW: OpenGL, O
 
 _These framebuffers can require conversion from RGB to MapColors, but options are provided to accelerate the process, see the end of the article (Color Mapping)._
 
-GLFW (and its LWJGL bindings) provide access to a window onto which a program can render. By making the window invisible, it is possible to render to an offscreen buffer, grab its contents and send it as a map.
+GLFW (and its LWJGL bindings) provide access to a window onto which a program can render. By making the window invisible, it is possible to render to an off-screen buffer, grab its contents and send it as a map.
 
 Which means you can use OpenGL to render onto maps! ![Partially-textured 3D block on a 4x4 wall map.](https://cdn.discordapp.com/attachments/706186241288306798/742862333046554624/2020-08-11_23.47.49.png)
 

--- a/docs/feature/permissions.md
+++ b/docs/feature/permissions.md
@@ -30,13 +30,13 @@ In order to add a permission to a player, you will have to call the `Player#addP
 player.addPermission(new Permission("operator"));
 ```
 
-If you want to check, if a player has a permission, you can use the `Player#hasPermission(Permission)` function, here is an example of checking for a permission inside of a command:
+If you want to check, if a player has a permission, you can use the `Player#hasPermission(Permission)` function, here is an example of checking a permission from a command:
 
 ```java
 public class StopCommand extends Command {
     public StopCommand() {
         super("stop");
-        setCondition((sender, commandString) -> sender.hasPermission(new Permission("operator"));
+        setCondition((sender, commandString) -> sender.hasPermission(new Permission("operator")));
         setDefaultExecutor((sender, context) -> MinecraftServer.stopCleanly());
     }
 }

--- a/docs/feature/player-capabilities.md
+++ b/docs/feature/player-capabilities.md
@@ -9,7 +9,7 @@ It is worth reviewing the [Adventure API](adventure) before this, because these 
 `Sidebar`s can be used to display up to 16 lines on a scoreboard for the player. They are created given a title as follows:
 
 ```java
-Sidebar#<init>(Component /* title */)
+Sidebar#<init>(Component /* title */);
 ```
 
 > Sidebar titles do not support JSON chat components, however the provided component will be serialized using Adventure's legacy serializer.

--- a/docs/feature/player-uuid.md
+++ b/docs/feature/player-uuid.md
@@ -2,7 +2,7 @@
 
 As UUID implies, it has to be a unique identifier. By default, this identifier is generated randomly at the connection so unique but not persistent.
 
-What you normally want is a unique identifier that will stay the same even after a disconnection or a server shutdown, which could be obtained by getting the Mojang UUID of the player using their API, or having your custom UUID linked to the registration system on your website, we do not implement that by default so you are free to choose what you prefer.
+What you normally want is a unique identifier that will stay the same even after a disconnection or a server shutdown, which could be obtained by getting the Mojang UUID of the player using their API, or having your custom UUID linked to the registration system on your website, we do not implement that by default, so you are free to choose what you prefer.
 
 Here how to register your own UUID provider:
 

--- a/docs/feature/tags.md
+++ b/docs/feature/tags.md
@@ -37,7 +37,7 @@ UUID uuid = instance.getTag(mappedTag);
 
 ```java
 Tag<String> stringTag = Tag.String("my-string");
-instance.getTag(stringTag.defaultValue("default"))
+instance.getTag(stringTag.defaultValue("default"));
 ```
 
 #### TagSerializer

--- a/docs/feature/tags.md
+++ b/docs/feature/tags.md
@@ -18,7 +18,7 @@ Tags benefit are:
 
 ## API
 
-First of all, it is recommenced to expose Tags as contant and reused. All `Tag` methods should be pure, and allow to specify additional information to handle the data.
+First of all, it is recommended to expose Tags as constant and reused. All `Tag` methods should be pure, and allow to specify additional information to handle the data.
 
 All tags are available as static factory methods inside the `Tag` class.
 
@@ -46,7 +46,7 @@ instance.getTag(stringTag.defaultValue("default"));
 
 #### Structure
 
-A structure tag is a wrapper around an nbt compound (map) independent from all the other tags.
+A structure tag is a wrapper around a nbt compound (map) independent of all the other tags.
 
 #### View
 

--- a/docs/thread-architecture/acquirable-api.md
+++ b/docs/thread-architecture/acquirable-api.md
@@ -27,11 +27,11 @@ System.out.println("Acquisition happened successfully");
 
 It is important to understand that the consumer is called in the same thread, it is the whole magic of the Acquirable API, your code stays the exact same.
 
-The entity object from the consumer should however **only** be used inside of the consumer. Meaning that if you need to save the entity somewhere for further processing, you shall use the acquirable object instead of the acquired one.
+The entity object from the consumer should however **only** be used inside the consumer. Meaning that if you need to save the entity somewhere for further processing, you shall use the acquirable object instead of the acquired one.
 
 ```java
     private Acquirable<Entity> myEntity; // <- GOOD
-    // private Entity myEntity <- NO GOOD, DONT DO THAT
+    // private Entity myEntity <- NO GOOD, DON'T DO THAT
 
     public void randomMethod(Acquirable<Entity> acquirableEntity) {
         this.myEntity = acquirableEntity;
@@ -82,7 +82,7 @@ acquiredPlayer.unlock();
 
 ### Acquirable Collections
 
-Let's say you have a `AcquirableCollection<Player>` and you want to access **safely** all of the players it contains. You have multiple solutions, each having pros & cons.
+Let's say you have a `AcquirableCollection<Player>` and you want to **safely** access all the players it contains. You have multiple solutions, each having pros & cons.
 
 #### Naive loop
 
@@ -144,7 +144,7 @@ I would personally recommend commenting everywhere you use those unsafe methods 
 Stream<Entity> entities = Acquirable.currentEntities();
 ```
 
-### What type to request and return in methods
+### What types to request and return in methods
 
 You have obviously the right to do what you prefer. But as a general rule, you should return `Acquirable<T>` objects and request for `T`.
 

--- a/docs/thread-architecture/acquirable-api.md
+++ b/docs/thread-architecture/acquirable-api.md
@@ -23,7 +23,7 @@ acquirableEntity.sync(entity -> {
 System.out.println("Acquisition happened successfully");
 ```
 
-`Acquirable#acquire` will block the current thread until `acquirableEntity` becomes accessible, and execute the consumer **in the same thread** once it is the case.
+`Acquirable#sync` will block the current thread until `acquirableEntity` becomes accessible, and execute the consumer **in the same thread** once it is the case.
 
 It is important to understand that the consumer is called in the same thread, it is the whole magic of the Acquirable API, your code stays the exact same.
 

--- a/docs/thread-architecture/acquirable-api/inside-the-api.md
+++ b/docs/thread-architecture/acquirable-api/inside-the-api.md
@@ -24,7 +24,7 @@ After a batch gets assigned to a thread, the same happens to every element added
 
 What advantage does it have? It allows us to know if the object in question can be safely accessed! When you execute Acquirable#acquire, it will first check if the current thread is the same as the one where the object to acquire will be ticked, meaning no synchronization required, the overhead in this case is a simple `Thread#currentThread` call.
 
-This is obviously the best scenario but it does not always happen, how does the system react if the two threads are different? Well firstly it will signal to the object's thread that an acquisition needs to happen and then block the current thread, and secondly, it will wait for the signaled thread to handle the acquisition. Acquisition signals are checked at the start of every entity tick, and at the end of the thread tick execution.
+This is obviously the best scenario, but it does not always happen. How does the system react if the two threads are different? Well firstly it will signal to the object's thread that an acquisition needs to happen and then block the current thread, and secondly, it will wait for the signaled thread to handle the acquisition. Acquisition signals are checked at the start of every entity tick, and at the end of the thread tick execution.
 
 During acquisition handling, the thread is blocked until all of them are processed and can then continue its execution safely.
 

--- a/docs/thread-architecture/thread-safety.md
+++ b/docs/thread-architecture/thread-safety.md
@@ -10,13 +10,13 @@ As for its usage in Minestom, you do not have to remember everything you will re
 
 ## What is thread-safety?
 
-A code is called "thread-safe" if and only if this code can be called from multiple threads without unexpected behavior. Therefore the term does not say anything about performance or design, it is simply a way to denote how the code can be accessed.
+A code is called "thread-safe" if and only if this code can be called from multiple threads without unexpected behavior. Therefore, the term does not say anything about performance or design, it is simply a way to denote how the code can be accessed.
 
 ## What does it cost?
 
-Transforming a single-threaded code to a multi-threaded one is not as easy as creating multiple threads. The main issue you will encounter is about memory visibility, you can imagine that 2 threads cannot access the same variable in memory at the exact same time without any drawback. Synchronization requires having the thread check if it has the right to access the X method and has therefore a cost, mostly in the order of nano or microseconds, but could lead to an unusable program if too repetitive. Common issues in multithreaded applications are:
+Transforming a single-threaded code to a multithreaded one is not as easy as creating multiple threads. The main issue you will encounter is about memory visibility, you can imagine that 2 threads cannot access the same variable in memory at the exact same time without any drawback. Synchronization requires having the thread check if it has the right to access the X method and has therefore a cost, mostly in the order of nano or microseconds, but could lead to an unusable program if too repetitive. Common issues in multithreaded applications are:
 
-1. Race-condition: when the same method is called by two threads at the same time, which generally lead to undebuggable issues
+1. Race-condition: when the same method is called by two threads at the same time, which generally causes issues that are hard to debug
 2. Deadlock: when two locks are waiting for each other, meaning that those will never be freed
 
 ## What to use?
@@ -33,6 +33,6 @@ Making a field thread-safe does not mean that the object itself is. But only tha
 
 ### Methods
 
-Additionally to the fields, you need to way to manage your flow control so two methods are not called at the exact time which is likely to break every non-thread-safe program (race-condition). Thread synchronization happens thanks to the help of locks, those are mechanisms that will make the current thread waits until someone tells him that he can now open the door and close behind him.
+In addition to the fields, you need to way to manage your flow control so two methods are not called at the exact time which is likely to break every non-thread-safe program (race-condition). Thread synchronization happens thanks to the help of locks, those are mechanisms that will make the current thread waits until someone tells him that he can now open the door and close behind him.
 
 The JVM is again here to the rescue with the `synchronized` flag or the low-level `Object#wait/notify()` methods. There are also higher-level tools such as `CountDownLatch`, `Phaser`, and even some handy safe collections to replace your non-thread-safe ones! `ConcurrentHashMap`, `CopyOnWriteArrayList`, `ConcurrentLinkedQueue`, and a lot of other ones available in your [JDK](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/package-summary.html).

--- a/docs/world/anvilloader.md
+++ b/docs/world/anvilloader.md
@@ -12,7 +12,7 @@ An example of using this method to load a world is:
 InstanceContainer.setChunkLoader(new AnvilLoader("worlds/world"));
 ```
 
-This will load the world inside of the `worlds/world` directory into the InstanceContainer, allowing you to use the instance as before but having the world loaded inside.
+This will load the world inside the `worlds/world` directory into the InstanceContainer, allowing you to use the instance as before but having the world loaded inside.
 
 In order to load a world, the world folder will only need the `/region` folder, as it contains the block data.
 

--- a/docs/world/batch.md
+++ b/docs/world/batch.md
@@ -56,7 +56,7 @@ RelativeBlockBatch#apply(Instance, BlockPosition, Runnable);
 RelativeBlockBatch#apply(Instance, int /* x */, int /* y */, int /* z */, Runnable);
 ```
 
-`RelativeBlockbatch` has a significant performance difference from the other two options, and they should be used over `RelativeBlockBatch` if possible. It is possible to convert a relative batch to an `AbsoluteBlockBatch` using the following methods. This should be used (and cached) if the batch will be applied several times to the same location.
+`AbsoluteBlockBatch` has a significant performance difference from the other two options, and they should be used over `RelativeBlockBatch` if possible. It is possible to convert a relative batch to an `AbsoluteBlockBatch` using the following methods. This should be used (and cached) if the batch will be applied several times to the same location.
 
 ```java
 RelativeBlockBatch#toAbsoluteBatch();

--- a/docs/world/batch.md
+++ b/docs/world/batch.md
@@ -1,6 +1,6 @@
 # Batch
 
-When manipulating a lot of blocks, it is wiser to make use of a Batch to update all of the chunks at once. There are 3 types of batches: `ChunkBatch`, `AbsoluteBlockBatch`, `RelativeBlockBatch`.
+When manipulating a lot of blocks, it is wiser to make use of a Batch to update all the chunks at once. There are 3 types of batches: `ChunkBatch`, `AbsoluteBlockBatch`, `RelativeBlockBatch`.
 
 All batches have a similar set of methods to set blocks, however the coordinate systems are not all the same. See the individual batch for specifics.
 

--- a/docs/world/chunk-management.md
+++ b/docs/world/chunk-management.md
@@ -12,7 +12,7 @@ When trying to load a chunk, the instance container does multiple checks in this
 
 1. Verify if the chunk is already loaded (stop here if yes)
 2. Try to load the chunk from the instance [IChunkLoader](https://minestom.github.io/Minestom/net/minestom/server/instance/IChunkLoader.html) using [IChunkLoader#loadChunk](https://minestom.github.io/Minestom/net/minestom/server/instance/IChunkLoader.html#loadChunk%28net.minestom.server.instance.Instance,int,int,net.minestom.server.utils.chunk.ChunkCallback%29) (stop here if the chunk loading is successful)
-3. Create a new chunk and execute the instance ChunkGenerator (if any) to it to generate all of the chunk's blocks.
+3. Create a new chunk and execute the instance ChunkGenerator (if any) to it to generate all the chunk's blocks.
 
 When trying to save a chunk, [IChunkLoader#saveChunk](https://minestom.github.io/Minestom/net/minestom/server/instance/IChunkLoader.html#saveChunk%28net.minestom.server.instance.Chunk,java.lang.Runnable%29) is called.
 

--- a/docs/world/generation.md
+++ b/docs/world/generation.md
@@ -57,7 +57,7 @@ instance.setGenerator(unit -> {
         return;
     }
 
-    // Lets fork this section to add our tall snowman.
+    // Let's fork this section to add our tall snowman.
     // We add two extra sections worth of space to this fork to fit the snowman.
     GenerationUnit fork = unit.fork(start, start.add(16, 32, 16));
 
@@ -110,7 +110,7 @@ Example with missing terrain for clarity:
 
 ## Heightmaps with JNoise
 
-This example shows a simply approach to building heightmaps using JNoise, this can be expanded to other noise implementations as well.
+This example shows a simple approach to building heightmaps using JNoise, this can be expanded to other noise implementations as well.
 
 ```java
 // Noise used for the height
@@ -136,6 +136,6 @@ instance.setGenerator(unit -> {
 });
 ```
 
-Here's and example of what that looks like:
+Here's an example of what that looks like:
 
 ![](/docs/world/generation/jnoise.png)

--- a/docs/world/instances.md
+++ b/docs/world/instances.md
@@ -12,7 +12,7 @@ InstanceManager instanceManager = MinecraftServer.getInstanceManager()
 Entity#getInstance
 ```
 
-Internally, the default Instance class have its own sets to store the entities in it, but all chunk based methods are abstract and meant to be implemented by a sub-class
+Internally, the default Instance class have its own sets to store the entities in it, but all chunk based methods are abstract and meant to be implemented by a subclass
 
 ## InstanceContainer
 

--- a/docs/world/lightloader.md
+++ b/docs/world/lightloader.md
@@ -6,7 +6,7 @@ description: >-
 ## Setting the chunk supplier
 
 To use the LightingChunk class, you can call the `InstanceContainer#setChunkSupplier(LightingChunk::new)` method.
-By default lighting will be generated for chunks when they are sent to the client.
+By default, lighting will be generated for chunks when they are sent to the client.
 
 An example of using this method:
 ```java


### PR DESCRIPTION
This PR fixes some general mistakes in the documentation I spotted while reading through it.
I also went through the documentation with IntelliJ and fixed most of the grammar, spelling and sentence flow mistakes I found.