### PR TITLE
Remove Kotlin from Wiki

### DIFF
--- a/docs/setup/your-first-server.md
+++ b/docs/setup/your-first-server.md
@@ -27,18 +27,6 @@ public static void main(String[] args) {
 ```
 
 ===
-=== Kotlin
-
-```kotlin
-fun main() {
-    // Initialize the server
-    val minecraftServer = MinecraftServer.init()
-
-    // Register Events (set spawn instance, teleport player at spawn)
-    // Start the server
-    minecraftServer.start("0.0.0.0", 25565)
-}
-```
 
 ===
 :::
@@ -59,15 +47,6 @@ globalEventHandler.addListener(AsyncPlayerConfigurationEvent.class, event -> {
 ```
 
 ===
-=== Kotlin
-
-```kotlin
-val instance = // create instance
-val globalEventHandler = MinecraftServer.getGlobalEventHandler();
-globalEventHandler.addListener(AsyncPlayerConfigurationEvent::class.java) { event ->
-    event.spawningInstance = instance
-}
-```
 
 ===
 :::
@@ -111,42 +90,6 @@ public class MainDemo {
         // Start the server on port 25565
         minecraftServer.start("0.0.0.0", 25565);
     }
-}
-```
-
-===
-=== Kotlin
-
-```kotlin
-package demo
-
-import net.minestom.server.MinecraftServer
-import net.minestom.server.instance.block.Block
-import net.minestom.server.coordinate.Pos
-import net.minestom.server.event.player.AsyncPlayerConfigurationEvent
-
-fun main() {
-    // Initialization
-    val minecraftServer = MinecraftServer.init()
-
-    // Create the instance
-    val instanceManager = MinecraftServer.getInstanceManager()
-    val instanceContainer = instanceManager.createInstanceContainer()
-
-    // Set the ChunkGenerator
-    instanceContainer.setGenerator { unit ->
-        unit.modifier().fillHeight(0, 40, Block.GRASS_BLOCK)
-    }
-
-    // Add an event callback to specify the spawning instance (and the spawn position)
-    val globalEventHandler = MinecraftServer.getGlobalEventHandler()
-    globalEventHandler.addListener(AsyncPlayerConfigurationEvent::class.java) { event ->
-        val player = event.getPlayer()
-        event.spawningInstance = instanceContainer
-        player.respawnPoint = Pos(0.0, 42.0, 0.0)
-    }
-
-    minecraftServer.start("0.0.0.0", 25565)
 }
 ```
 


### PR DESCRIPTION
There is no reason to keep it as Minestom is based in Java and the conversion is unnecessary + adds more code to be maintained to the wiki.